### PR TITLE
configure windmove to wrap around

### DIFF
--- a/rally/window.el
+++ b/rally/window.el
@@ -2,3 +2,4 @@
 (global-unset-key (kbd "<select>"))
 (windmove-default-keybindings) ;; Shift+direction
 (global-set-key (kbd "<select>") 'windmove-up)
+(setq windmove-wrap-around t)


### PR DESCRIPTION
This causes windmove to do the sensible thing by e.g. jumping to the leftmost window if S-<right> is pressed in the rightmost buffer, or the bottom window when S-<up> is pressed in the top buffer. Currently is simply sends an error message in these cases.