### PR TITLE
Removing ack-and-a-half because it's now abandonware.

### DIFF
--- a/init.el
+++ b/init.el
@@ -33,7 +33,8 @@
 ;;(vendor 'jtags)
 (vendor 'scala-mode)
 (vendor 'projectile)
-(vendor 'ack-and-a-half 'ack-and-a-half 'ack-and-a-half-same 'ack-and-a-half-find-file 'ack-and-a-half-find-file-same 'ack-and-a-half-interactive)
+;; ack-and-a-half has been abandonwared
+;;(vendor 'ack-and-a-half 'ack-and-a-half 'ack-and-a-half-same 'ack-and-a-half-find-file 'ack-and-a-half-find-file-same 'ack-and-a-half-interactive)
 (vendor 'smex)
 (vendor 'color-theme)
 (vendor 'magit)

--- a/init.el
+++ b/init.el
@@ -36,6 +36,7 @@
 ;; ack-and-a-half has been abandonwared
 ;;(vendor 'ack-and-a-half 'ack-and-a-half 'ack-and-a-half-same 'ack-and-a-half-find-file 'ack-and-a-half-find-file-same 'ack-and-a-half-interactive)
 (vendor 'smex)
+(vendor 'ag)
 (vendor 'color-theme)
 (vendor 'magit)
 (vendor 'yasnippet)

--- a/rally/bindings.el
+++ b/rally/bindings.el
@@ -6,10 +6,12 @@
 (global-set-key (kbd "C-S-k")     'kill-this-buffer)
 (global-set-key (kbd "C-x C-k k") 'kill-this-buffer)
 
-(global-set-key (kbd "C-S-f")     'ack-and-a-half) ; doesn't work in terminal
-(global-set-key (kbd "C-x C-a")   'ack-and-a-half)
-(global-set-key (kbd "C-x M-g")   'ack-and-a-half-same)
-(global-set-key (kbd "C-x C-g")   'git-grep-dwim)
+;;(global-set-key (kbd "C-S-f")     'ack-and-a-half) ; doesn't work in terminal
+;;(global-set-key (kbd "C-x C-a")   'ack-and-a-half)
+;;(global-set-key (kbd "C-x M-g")   'ack-and-a-half-same)
+
+;;(global-set-key (kbd "C-x C-g")   'git-grep-dwim)
+(global-set-key (kbd "C-x C-g")   'ag-project)
 
 (global-set-key (kbd "C-x M-d")   'dired-r)
 (global-set-key (kbd "<f8>")      'toggle-truncate-lines)

--- a/rally/grep.el
+++ b/rally/grep.el
@@ -9,7 +9,7 @@
 ;; Only works inside a git project, but that's almost always what I
 ;; want. 
 (defun git-grep-dwim (regexp &optional files dir)
-  (interactive
-   (list (grep-read-regexp) "*" (progn (require 'ack-and-a-half)
-                                       (ack-and-a-half-guess-project-root))))
+  ;;(interactive
+  ;; (list (grep-read-regexp) "*" (progn (require 'ack-and-a-half)
+  ;;                                     (ack-and-a-half-guess-project-root))))
   (vc-git-grep regexp files dir))


### PR DESCRIPTION
Not sure what else needs doing.  ctrl-x-ctrl-g was already using git-grep.  The Internets say that ag is an alternative.  Could it be used ??