### PR TITLE
Make 'vendor interactive

### DIFF
--- a/rally/defuns.el
+++ b/rally/defuns.el
@@ -16,6 +16,7 @@
 ;; - Load from <library>.el file in vendor/
 ;; - Load from installed package
 (defun vendor (library &rest autoload-functions)
+  (interactive "SLibrary: ")
   (let* ((file (symbol-name library))
          (normal (concat "~/.emacs.d/vendor/" file))
          (suffix (concat normal ".el"))


### PR DESCRIPTION
This will help with installing packages that are party of
rally-emacs that have not yet been turned on by default.