### PR TITLE
Disable ESC delay.

### DIFF
--- a/tmux.conf.osx
+++ b/tmux.conf.osx
@@ -50,6 +50,7 @@ setw -g clock-mode-colour colour32
 setw -g clock-mode-style 24
 setw -g aggressive-resize on
 set -g base-index 1
+set -sg escape-time 0
 
 # More straight forward key bindings for splitting
 bind-key | split-window -h


### PR DESCRIPTION
The ESC delay makes working in vi painful.
I've had it disabled locally for awhile and figured I should push it back upstream.